### PR TITLE
Add support for Anthropic models in OpenRouter integration

### DIFF
--- a/convert_polis.py
+++ b/convert_polis.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import csv
+import sys
+
+def convert_polis_csv(input_file, output_file):
+    """Convert Polis export CSV to sensemaker format"""
+    with open(input_file, 'r', encoding='utf-8') as infile, \
+         open(output_file, 'w', encoding='utf-8', newline='') as outfile:
+
+        reader = csv.DictReader(infile)
+
+        # Define output fields
+        fieldnames = ['comment-id', 'comment_text', 'votes', 'agrees', 'disagrees', 'passes']
+
+        writer = csv.DictWriter(outfile, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for row in reader:
+            agrees = int(row.get('agrees', 0))
+            disagrees = int(row.get('disagrees', 0))
+            passes = 0  # Polis export doesn't include passes
+            votes = agrees + disagrees + passes
+
+            new_row = {
+                'comment-id': row['comment-id'],
+                'comment_text': row['comment-body'],
+                'votes': votes,
+                'agrees': agrees,
+                'disagrees': disagrees,
+                'passes': passes
+            }
+
+            writer.writerow(new_row)
+
+if __name__ == "__main__":
+    input_file = sys.argv[1] if len(sys.argv) > 1 else './files/polis_comments.csv'
+    output_file = sys.argv[2] if len(sys.argv) > 2 else './files/comments.csv'
+
+    convert_polis_csv(input_file, output_file)
+    print(f"Converted {input_file} to {output_file}")

--- a/library/src/models/openrouter_model.ts
+++ b/library/src/models/openrouter_model.ts
@@ -69,7 +69,7 @@ export class OpenRouterModel extends Model {
       
       if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
         // 檢查是否有常見的包裝鍵
-        const wrapperKeys = ['items', 'data', 'result', 'content', 'output'];
+        const wrapperKeys = ['items', 'data', 'result', 'content', 'output', 'topics'];
         for (const key of wrapperKeys) {
           if (key in parsed && Array.isArray(parsed[key])) {
             console.log(`   🔧 Detected wrapped array in '${key}' key, extracting...`);
@@ -130,15 +130,26 @@ export class OpenRouterModel extends Model {
           // 如果有 schema，設定結構化輸出
       if (schema) {
         // OpenRouter 支援 json_schema 格式，格式與官方文檔一致
+        // Anthropic 模型不支援 strict 參數，所以對 Anthropic 模型使用不同的設定
+        const isAnthropicModel = this.modelName.startsWith('anthropic/');
+
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (requestBody as any).response_format = {
-          type: "json_schema",
-          json_schema: {
-            name: "response",
-            strict: true,
-            schema: schema
-          }
-        };
+        if (isAnthropicModel) {
+          // Anthropic 模型使用簡化的 JSON mode
+          (requestBody as any).response_format = {
+            type: "json_object"
+          };
+        } else {
+          // 其他模型使用完整的 json_schema 格式
+          (requestBody as any).response_format = {
+            type: "json_schema",
+            json_schema: {
+              name: "response",
+              strict: true,
+              schema: schema
+            }
+          };
+        }
       }
 
     let lastError: Error | null = null;


### PR DESCRIPTION
## Summary
This PR adds full support for Anthropic models (like Claude Opus 4.6) when using the OpenRouter API integration.

## Problem
The existing OpenRouter implementation used `strict: true` in the `json_schema` response format, which is not supported by Anthropic models through OpenRouter. This caused 400 Bad Request errors when trying to use models like `anthropic/claude-opus-4.6`.

## Solution
1. **Conditional response format**: Detect Anthropic models and use `json_object` mode instead of strict `json_schema`
2. **Enhanced wrapper detection**: Add 'topics' to the list of wrapper keys to handle Anthropic's response format patterns
3. **Polis conversion utility**: Include `convert_polis.py` script to simplify converting Polis CSV exports

## Changes
- Modified `library/src/models/openrouter_model.ts`:
  - Added detection for Anthropic models (checking if model name starts with 'anthropic/')
  - Use simplified `json_object` response format for Anthropic models
  - Added 'topics' to wrapper key detection array
- Added `convert_polis.py`: Utility to convert Polis CSV format to sensemaker format

## Testing
✅ Successfully tested with `anthropic/claude-opus-4.6` model
✅ Processed 31-statement Polis conversation with 1,138 votes
✅ Generated all output formats (HTML, Markdown, JSON, CSV)
✅ Topic identification, categorization, and summarization all working

## Example Usage
\`\`\`bash
export OPENROUTER_API_KEY="your-key-here"
export OPENROUTER_MODEL="anthropic/claude-opus-4.6"
tsx library/runner-cli/runner_openrouter.ts \
  --outputBasename ./output \
  --inputFile ./comments.csv \
  --additionalContext "Conversation description"
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)