### PR TITLE
Add support for Anthropic models in OpenRouter integration

### DIFF
--- a/convert_polis.py
+++ b/convert_polis.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import csv
+import sys
+
+def convert_polis_csv(input_file, output_file):
+    """Convert Polis export CSV to sensemaker format"""
+    with open(input_file, 'r', encoding='utf-8') as infile, \
+         open(output_file, 'w', encoding='utf-8', newline='') as outfile:
+
+        reader = csv.DictReader(infile)
+
+        # Define output fields
+        fieldnames = ['comment-id', 'comment_text', 'votes', 'agrees', 'disagrees', 'passes']
+
+        writer = csv.DictWriter(outfile, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for row in reader:
+            agrees = int(row.get('agrees', 0))
+            disagrees = int(row.get('disagrees', 0))
+            passes = 0  # Polis export doesn't include passes
+            votes = agrees + disagrees + passes
+
+            new_row = {
+                'comment-id': row['comment-id'],
+                'comment_text': row['comment-body'],
+                'votes': votes,
+                'agrees': agrees,
+                'disagrees': disagrees,
+                'passes': passes
+            }
+
+            writer.writerow(new_row)
+
+if __name__ == "__main__":
+    input_file = sys.argv[1] if len(sys.argv) > 1 else './files/polis_comments.csv'
+    output_file = sys.argv[2] if len(sys.argv) > 2 else './files/comments.csv'
+
+    convert_polis_csv(input_file, output_file)
+    print(f"Converted {input_file} to {output_file}")

--- a/library/src/models/openrouter_model.ts
+++ b/library/src/models/openrouter_model.ts
@@ -69,7 +69,7 @@ export class OpenRouterModel extends Model {
       
       if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
         // 檢查是否有常見的包裝鍵
-        const wrapperKeys = ['items', 'data', 'result', 'content', 'output'];
+        const wrapperKeys = ['items', 'data', 'result', 'content', 'output', 'topics'];
         for (const key of wrapperKeys) {
           if (key in parsed && Array.isArray(parsed[key])) {
             console.log(`   🔧 Detected wrapped array in '${key}' key, extracting...`);
@@ -130,15 +130,26 @@ export class OpenRouterModel extends Model {
           // 如果有 schema，設定結構化輸出
       if (schema) {
         // OpenRouter 支援 json_schema 格式，格式與官方文檔一致
+        // Anthropic 模型不支援 strict 參數，所以對 Anthropic 模型使用不同的設定
+        const isAnthropicModel = this.modelName.startsWith('anthropic/');
+
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (requestBody as any).response_format = {
-          type: "json_schema",
-          json_schema: {
-            name: "response",
-            strict: true,
-            schema: schema
-          }
-        };
+        if (isAnthropicModel) {
+          // Anthropic 模型使用簡化的 JSON mode
+          (requestBody as any).response_format = {
+            type: "json_object"
+          };
+        } else {
+          // 其他模型使用完整的 json_schema 格式
+          (requestBody as any).response_format = {
+            type: "json_schema",
+            json_schema: {
+              name: "response",
+              strict: true,
+              schema: schema
+            }
+          };
+        }
       }
 
     let lastError: Error | null = null;


### PR DESCRIPTION
## Summary
- Use `json_object` mode for Anthropic models instead of strict `json_schema` (Anthropic models don't support the strict parameter)
- Add `topics` to wrapper key detection to handle Anthropic's response format
- Add `convert_polis.py` utility script to convert Polis CSV exports to the required sensemaker format

Successfully tested with `anthropic/claude-opus-4.6` model on a 31-statement Polis conversation.

(Same as #44, re-targeted to `new-feature-open-router` per [Discussion #45](https://github.com/bestian/sensemaking-tools/discussions/45))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>